### PR TITLE
feat(database): initialize prisma schema and migrations

### DIFF
--- a/apps/server/prisma/migrations/20260218213209_init_schema/migration.sql
+++ b/apps/server/prisma/migrations/20260218213209_init_schema/migration.sql
@@ -1,0 +1,54 @@
+/*
+  Warnings:
+
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `username` on the `User` table. All the data in the column will be lost.
+  - Added the required column `password` to the `User` table without a default value. This is not possible if the table is not empty.
+  - Made the column `name` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropIndex
+DROP INDEX "User_username_key";
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+DROP COLUMN "username",
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "password" TEXT NOT NULL,
+ADD COLUMN     "role" TEXT NOT NULL DEFAULT 'USER',
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "name" SET NOT NULL,
+ADD CONSTRAINT "User_pkey" PRIMARY KEY ("id");
+
+-- CreateTable
+CREATE TABLE "Question" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authorId" TEXT NOT NULL,
+
+    CONSTRAINT "Question_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Answer" (
+    "id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "questionId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+
+    CONSTRAINT "Answer_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Question" ADD CONSTRAINT "Question_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Answer" ADD CONSTRAINT "Answer_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "Question"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Answer" ADD CONSTRAINT "Answer_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -8,8 +8,33 @@ datasource db {
 }
 
 model User {
-  id    String @id @default(dbgenerated("uuidv7()")) @db.Uuid
-  email String @unique
-  username String @unique
-  name  String?
+  id        String   @id @default(uuid())
+  email     String   @unique
+  name      String
+  role      String   @default("USER")
+  password  String
+  createdAt DateTime @default(now())
+  questions Question[] 
+  answers   Answer[]  
+}
+
+model Question {
+  id        String   @id @default(uuid())
+  title     String
+  subject   String
+  body      String
+  createdAt DateTime @default(now())
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  String
+  answers   Answer[]
+}
+
+model Answer {
+  id        String   @id @default(uuid())
+  body      String
+  createdAt DateTime @default(now())
+  question   Question @relation(fields: [questionId], references: [id])
+  questionId String
+  author     User     @relation(fields: [authorId], references: [id])
+  authorId   String
 }


### PR DESCRIPTION
## 🚀 Description
This PR initializes the core data layer for the project. It sets up the PostgreSQL database structure using Prisma ORM and defines the relationships between our primary entities as outlined in our UML diagram.

## 🛠️ Changes Made
- Schema Definition: Created models for User, Question, Answer.

- Relationship Mapping: * Implemented One-to-Many links between Users and their Questions/Answers.

- Initial Migration: Generated the init_schema migration file to sync the database state.